### PR TITLE
Fix for #6 - Escape directory in patch command to accomodate for paths with spaces

### DIFF
--- a/repackager.js
+++ b/repackager.js
@@ -45,5 +45,5 @@ function alreadySetup() {
 }
 
 function patch(patchFileName) {
-  exec.execSync(`patch ${shouldReverse ? '--reverse' : ''} --strip 1 --directory node_modules/react-native < ${scriptDir}/${patchFileName}.patch`);
+  exec.execSync(`patch ${shouldReverse ? '--reverse' : ''} --strip 1 --directory node_modules/react-native < "${scriptDir}/${patchFileName}.patch"`);
 }


### PR DESCRIPTION
This fixes issue #6 by wrapping the `patch` path with quotes. Without this fix repackager can't run if any directory in the path contains spaces.